### PR TITLE
Improve parent hotline quick action behavior

### DIFF
--- a/data.json
+++ b/data.json
@@ -109,7 +109,9 @@
       "shareViaWhatsApp": "Share via WhatsApp",
       "getApp": "Get Emergency App",
       "checkEligibility": "Check Eligibility",
-      "legalHelp": "Legal Help"
+      "legalHelp": "Legal Help",
+      "phoneDesktopPrompt": "Call this number from your phone:",
+      "phoneCopied": "Number copied to clipboard."
     },
     "es": {
       "title": "Guía de Seguridad Migratoria 2025",
@@ -121,7 +123,9 @@
       "shareViaWhatsApp": "Compartir por WhatsApp",
       "getApp": "Obtener App de Emergencia",
       "checkEligibility": "Verificar Elegibilidad",
-      "legalHelp": "Ayuda Legal"
+      "legalHelp": "Ayuda Legal",
+      "phoneDesktopPrompt": "Llame a este número desde su teléfono:",
+      "phoneCopied": "Número copiado al portapapeles."
     }
   },
   

--- a/index.html
+++ b/index.html
@@ -708,6 +708,17 @@
                 if (action.type === 'app' && action.action === 'detectDevice') {
                     button.href = '#';
                     button.addEventListener('click', event => getReadyNowApp(event, action.id));
+                } else if (action.type === 'phone') {
+                    button.href = action.action || '#';
+                    const phoneNumber = (action.action || '').replace(/^tel:/i, '').trim();
+                    if (phoneNumber) {
+                        button.dataset.phoneNumber = phoneNumber;
+                        button.title = `${label} ${phoneNumber}`.trim();
+                        button.setAttribute('aria-label', `${label} ${phoneNumber}`.trim());
+                    } else {
+                        button.setAttribute('aria-label', label);
+                    }
+                    button.addEventListener('click', event => handlePhoneAction(event, action.action, label));
                 } else {
                     button.href = action.action || '#';
                     if (action.type === 'external') {
@@ -718,6 +729,46 @@
 
                 container.appendChild(button);
             });
+        }
+
+        function handlePhoneAction(event, phoneLink, label = '') {
+            if (event) {
+                event.preventDefault();
+            }
+
+            if (!phoneLink) {
+                return;
+            }
+
+            const phoneNumber = phoneLink.replace(/^tel:/i, '').trim();
+            const translations = appData.uiTranslations?.[currentLanguage] || appData.uiTranslations?.en || {};
+            const promptMessage = translations.phoneDesktopPrompt || 'Call this number from your phone:';
+            const copiedMessage = translations.phoneCopied || 'Number copied to clipboard.';
+            const userAgent = navigator.userAgent || navigator.vendor || window.opera || '';
+            const isMobileDevice = /Mobi|Android|iPhone|iPad|iPod/.test(userAgent);
+
+            if (isMobileDevice) {
+                window.location.href = phoneLink;
+                return;
+            }
+
+            if (phoneNumber && navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+                navigator.clipboard.writeText(phoneNumber)
+                    .then(() => {
+                        alert(`${promptMessage} ${phoneNumber}\n${copiedMessage}`);
+                    })
+                    .catch(() => {
+                        alert(`${promptMessage} ${phoneNumber}`);
+                    });
+                return;
+            }
+
+            const message = phoneNumber ? `${promptMessage} ${phoneNumber}` : promptMessage;
+            if (label && !phoneNumber) {
+                alert(`${label}\n${message}`);
+            } else {
+                alert(message);
+            }
         }
 
         function renderFilterChips() {


### PR DESCRIPTION
## Summary
- add specialized handling for phone quick actions so the parent hotline opens the dialer on mobile and shows the number on desktop
- include new localized messages for the hotline desktop fallback experience

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68ca1dd437a48332ae34988ad6bd694d