### PR TITLE
Start podcast player minimized by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1170,10 +1170,10 @@
     </div>
 
     <!-- Podcast Player -->
-    <div class="podcast-player" id="podcastPlayer">
+    <div class="podcast-player minimized" id="podcastPlayer">
         <div class="podcast-header">
             <span class="podcast-title" data-en="AUDIO GUIDE" data-es="GUÍA DE AUDIO">AUDIO GUIDE</span>
-            <button class="minimize-btn" onclick="togglePlayerSize()">⊟</button>
+            <button class="minimize-btn" onclick="togglePlayerSize()">▶</button>
         </div>
         <div class="player-content">
             <div class="episode-selector">


### PR DESCRIPTION
## Summary
- start the podcast player widget minimized so interactive controls stay unobtrusive on load
- update the toggle control to display a play icon that indicates the minimized state

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_b_68ca533c68048332ad893d210e1af82b