### PR TITLE
Improve responsive layout and popover behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
             font-size: 16px;
         }
 
+        body.popover-open {
+            overflow: hidden;
+        }
+
         /* Typography Scale */
         .display-1 {
             font-family: 'Playfair Display', serif;
@@ -153,10 +157,14 @@
             border: 1px solid var(--border-light);
             transform: translateX(0);
             transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            opacity: 1;
+            pointer-events: auto;
         }
 
         .nav.hidden {
             transform: translateX(calc(100% + 40px));
+            opacity: 0;
+            pointer-events: none;
         }
 
         .nav-toggle {
@@ -376,107 +384,111 @@
         /* Interactive Circles */
         .circles-container {
             position: relative;
-            width: 100%;
-            max-width: 900px;
-            height: 900px;
+            width: min(100%, 900px);
+            aspect-ratio: 1 / 1;
+            height: min(100vw, 900px);
             margin: 4rem auto;
             display: flex;
             align-items: center;
             justify-content: center;
             background: white;
             border-radius: 20px;
-            padding: 3rem;
+            padding: clamp(2rem, 5vw, 3rem);
             box-shadow: 0 20px 60px rgba(0,0,0,0.08);
+            overflow: visible;
         }
 
         .care-circle {
             position: absolute;
+            top: 50%;
+            left: 50%;
             border: 3px solid;
             border-radius: 50%;
             display: flex;
             align-items: center;
             justify-content: center;
-            transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+            transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.4s ease;
             cursor: pointer;
             font-weight: bold;
-            font-size: 1.5rem;
+            font-size: clamp(1rem, 1.6vw, 1.5rem);
             font-family: 'Playfair Display', serif;
+            transform: translate(-50%, -50%);
         }
 
-        .circle-1 { 
-            width: 100px; 
-            height: 100px; 
+        .circle-1 {
+            width: 16%;
+            height: 16%;
             border-color: var(--sphere-1);
             background: radial-gradient(circle, var(--sphere-1), transparent);
             z-index: 9;
         }
 
-        .circle-2 { 
-            width: 180px; 
-            height: 180px; 
+        .circle-2 {
+            width: 26%;
+            height: 26%;
             border-color: var(--sphere-2);
             background: radial-gradient(circle, rgba(249, 115, 22, 0.15), transparent);
             z-index: 8;
         }
 
-        .circle-3 { 
-            width: 260px; 
-            height: 260px; 
+        .circle-3 {
+            width: 36%;
+            height: 36%;
             border-color: var(--sphere-3);
             background: radial-gradient(circle, rgba(234, 179, 8, 0.12), transparent);
             z-index: 7;
         }
 
-        .circle-4 { 
-            width: 340px; 
-            height: 340px; 
+        .circle-4 {
+            width: 46%;
+            height: 46%;
             border-color: var(--sphere-4);
             background: radial-gradient(circle, rgba(132, 204, 22, 0.1), transparent);
             z-index: 6;
         }
 
-        .circle-5 { 
-            width: 420px; 
-            height: 420px; 
+        .circle-5 {
+            width: 56%;
+            height: 56%;
             border-color: var(--sphere-5);
             background: radial-gradient(circle, rgba(6, 182, 212, 0.08), transparent);
             z-index: 5;
         }
 
-        .circle-6 { 
-            width: 500px; 
-            height: 500px; 
+        .circle-6 {
+            width: 66%;
+            height: 66%;
             border-color: var(--sphere-6);
             background: radial-gradient(circle, rgba(139, 92, 246, 0.06), transparent);
             z-index: 4;
         }
 
-        .circle-7 { 
-            width: 580px; 
-            height: 580px; 
+        .circle-7 {
+            width: 76%;
+            height: 76%;
             border-color: var(--sphere-7);
             background: radial-gradient(circle, rgba(236, 72, 153, 0.05), transparent);
             z-index: 3;
         }
 
-        .circle-8 { 
-            width: 660px; 
-            height: 660px; 
+        .circle-8 {
+            width: 86%;
+            height: 86%;
             border-color: var(--sphere-8);
             background: radial-gradient(circle, rgba(20, 184, 166, 0.04), transparent);
             z-index: 2;
         }
 
-        .circle-9 { 
-            width: 740px; 
-            height: 740px; 
+        .circle-9 {
+            width: 96%;
+            height: 96%;
             border-color: var(--sphere-9);
             background: radial-gradient(circle, rgba(99, 102, 241, 0.03), transparent);
             z-index: 1;
         }
 
         .care-circle:hover {
-            transform: scale(1.05);
+            transform: translate(-50%, -50%) scale(1.05);
             box-shadow: 0 0 40px currentColor;
         }
 
@@ -485,17 +497,30 @@
             position: absolute;
             background: white;
             border-radius: 16px;
-            padding: 2rem;
-            width: 420px;
+            padding: clamp(1.5rem, 2.5vw, 2rem);
+            width: min(420px, calc(100% - 40px));
             box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
             z-index: 100;
             display: none;
             animation: popoverAppear 0.3s ease-out;
             border: 1px solid var(--border-light);
+            max-height: calc(100vh - 120px);
+            overflow-y: auto;
         }
 
         .sphere-popover.active {
             display: block;
+        }
+
+        .sphere-popover.mobile-active {
+            position: fixed;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            width: min(420px, calc(100vw - 2.5rem));
+            max-height: calc(100vh - 3rem);
+            padding: 1.5rem;
+            z-index: 1200;
         }
 
         @keyframes popoverAppear {
@@ -1069,17 +1094,40 @@
         /* Responsive */
         @media (max-width: 1024px) {
             .nav {
-                display: none;
+                left: 20px;
+                right: 20px;
+                top: 90px;
+                max-width: none;
+                width: auto;
+                max-height: calc(100vh - 140px);
+                overflow-y: auto;
+                padding: 1.5rem;
             }
-            
+
+            .nav.hidden {
+                transform: translateY(-10px);
+            }
+
             .nav-toggle {
                 display: flex;
             }
-            
+
+            .container {
+                padding: 0 1.5rem;
+            }
+
+            .section {
+                padding: 4.5rem 0;
+            }
+
             .hero-grid {
                 grid-template-columns: 1fr;
             }
-            
+
+            .hero-content {
+                padding: 3rem 2.5rem;
+            }
+
             .hero-visual {
                 height: 40vh;
                 order: -1;
@@ -1087,31 +1135,68 @@
         }
 
         @media (max-width: 768px) {
+            .language-toggle {
+                top: 16px;
+                right: 16px;
+            }
+
+            .nav-toggle {
+                top: 72px;
+                right: 16px;
+            }
+
+            .nav {
+                top: 82px;
+                left: 16px;
+                right: 16px;
+                max-height: calc(100vh - 130px);
+            }
+
+            .hero-content {
+                padding: 2.5rem 1.75rem;
+            }
+
             .circles-container {
-                height: 600px;
-                transform: scale(0.65);
+                width: min(100%, 540px);
+                padding: 2rem;
+                margin: 3rem auto;
             }
-            
+
+            .care-circle {
+                font-size: clamp(0.95rem, 3.2vw, 1.2rem);
+            }
+
             .sphere-popover {
-                width: 90%;
-                max-width: 360px;
+                width: min(380px, calc(100% - 32px));
+                max-height: calc(100vh - 160px);
             }
-            
+
             .photo-grid {
                 grid-template-columns: 1fr;
             }
-            
+
             .photo-sidebar {
                 flex-direction: row;
                 overflow-x: auto;
             }
-            
+
             .photo-sidebar img {
                 min-width: 200px;
             }
-            
+
             .case-journey {
                 grid-template-columns: 1fr;
+            }
+
+            .podcast-player {
+                right: 16px;
+                bottom: 16px;
+                width: min(360px, calc(100% - 32px));
+            }
+
+            .accessibility-bar {
+                left: 16px;
+                bottom: 16px;
             }
         }
 
@@ -1119,13 +1204,39 @@
             .tactical-goals {
                 grid-template-columns: 1fr;
             }
-            
+
             .hero-content {
                 padding: 2rem;
             }
-            
+
             .display-1 {
                 font-size: 2.5rem;
+            }
+
+            .container {
+                padding: 0 1.25rem;
+            }
+
+            .section {
+                padding: 3.5rem 0;
+            }
+
+            .circles-container {
+                padding: 1.5rem;
+            }
+
+            .podcast-player {
+                width: calc(100% - 32px);
+            }
+
+            .podcast-player.minimized {
+                width: 56px;
+                height: 56px;
+            }
+
+            .accessibility-bar button {
+                width: 36px;
+                height: 36px;
             }
         }
     </style>
@@ -1143,7 +1254,7 @@
     </div>
 
     <!-- Navigation -->
-    <button class="nav-toggle" onclick="toggleNav()">☰</button>
+    <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-controls="nav" aria-expanded="false" onclick="toggleNav()">☰</button>
     <nav class="nav hidden" id="nav">
         <div class="nav-header" data-en="Navigate" data-es="Navegar">Navigate</div>
         <a href="#intro" class="nav-item" data-en="Introduction" data-es="Introducción">Introduction</a>
@@ -2326,6 +2437,12 @@
         // Navigation active states and smooth scrolling
         const sections = document.querySelectorAll('section[id]');
         const navItems = document.querySelectorAll('.nav-item');
+        const nav = document.getElementById('nav');
+        const navToggleBtn = document.querySelector('.nav-toggle');
+
+        if (navToggleBtn) {
+            navToggleBtn.setAttribute('aria-expanded', 'false');
+        }
 
         window.addEventListener('scroll', () => {
             let current = '';
@@ -2354,13 +2471,41 @@
                 if (targetSection) {
                     targetSection.scrollIntoView({ behavior: 'smooth' });
                 }
+
+                if (nav) {
+                    nav.classList.add('hidden');
+                }
+
+                if (navToggleBtn) {
+                    navToggleBtn.setAttribute('aria-expanded', 'false');
+                }
             });
         });
 
+        if (nav && navToggleBtn) {
+            document.addEventListener('click', (event) => {
+                if (!nav.contains(event.target) && !navToggleBtn.contains(event.target)) {
+                    nav.classList.add('hidden');
+                    navToggleBtn.setAttribute('aria-expanded', 'false');
+                }
+            });
+        }
+
         // Toggle navigation visibility
         function toggleNav() {
-            const nav = document.getElementById('nav');
-            nav.classList.toggle('hidden');
+            if (!nav) return;
+            const isHidden = nav.classList.toggle('hidden');
+
+            if (navToggleBtn) {
+                navToggleBtn.setAttribute('aria-expanded', (!isHidden).toString());
+            }
+
+            if (!isHidden) {
+                const firstItem = nav.querySelector('.nav-item');
+                if (firstItem) {
+                    firstItem.focus();
+                }
+            }
         }
 
         // Language switching
@@ -2535,18 +2680,65 @@
 
         let currentOpenSphere = null;
 
+        function positionPopover(element) {
+            const popover = document.getElementById('spherePopover');
+            const container = document.querySelector('.circles-container');
+
+            if (!popover) return;
+
+            popover.classList.remove('mobile-active');
+            document.body.classList.remove('popover-open');
+            popover.style.left = '';
+            popover.style.top = '';
+            popover.style.width = '';
+            popover.style.transform = '';
+
+            const isMobile = window.matchMedia('(max-width: 768px)').matches;
+
+            if (isMobile) {
+                popover.classList.add('mobile-active');
+                document.body.classList.add('popover-open');
+                return;
+            }
+
+            if (!element || !container) {
+                return;
+            }
+
+            const rect = element.getBoundingClientRect();
+            const containerRect = container.getBoundingClientRect();
+            const popoverWidth = Math.min(420, Math.max(280, containerRect.width - 40));
+            popover.style.width = popoverWidth + 'px';
+
+            const popoverHeight = popover.offsetHeight || 320;
+
+            let left = rect.left - containerRect.left + rect.width / 2 - popoverWidth / 2;
+            let top = rect.top - containerRect.top + rect.height + 20;
+
+            if (left < 20) left = 20;
+            if (left + popoverWidth > containerRect.width - 20) {
+                left = containerRect.width - popoverWidth - 20;
+            }
+
+            if (top + popoverHeight > containerRect.height) {
+                top = rect.top - containerRect.top - popoverHeight - 20;
+            }
+
+            popover.style.left = `${left}px`;
+            popover.style.top = `${Math.max(20, top)}px`;
+        }
+
         function showPopover(sphereNumber, element) {
             const data = sphereData[sphereNumber];
             const popover = document.getElementById('spherePopover');
-            const container = document.querySelector('.circles-container');
-            
-            if (currentOpenSphere === sphereNumber) {
+
+            if (currentOpenSphere === sphereNumber && popover && popover.classList.contains('active')) {
                 closePopover();
                 return;
             }
-            
+
             currentOpenSphere = sphereNumber;
-            
+
             const popoverContent = `
                 <div class="popover-header">
                     <div class="popover-title">
@@ -2568,31 +2760,24 @@
             `;
             
             document.getElementById('popoverContent').innerHTML = popoverContent;
-            
-            // Position popover
-            const rect = element.getBoundingClientRect();
-            const containerRect = container.getBoundingClientRect();
-            const popoverWidth = 420;
-            
-            let left = rect.left - containerRect.left + rect.width/2 - popoverWidth/2;
-            let top = rect.top - containerRect.top + rect.height + 20;
-            
-            if (left < 20) left = 20;
-            if (left + popoverWidth > containerRect.width - 20) {
-                left = containerRect.width - popoverWidth - 20;
+
+            if (popover) {
+                popover.classList.add('active');
             }
-            
-            if (top + 350 > containerRect.height) {
-                top = rect.top - containerRect.top - 370;
-            }
-            
-            popover.style.left = left + 'px';
-            popover.style.top = top + 'px';
-            popover.classList.add('active');
+
+            positionPopover(element);
         }
 
         window.closePopover = function() {
-            document.getElementById('spherePopover').classList.remove('active');
+            const popover = document.getElementById('spherePopover');
+            if (popover) {
+                popover.classList.remove('active', 'mobile-active');
+                popover.style.left = '';
+                popover.style.top = '';
+                popover.style.width = '';
+                popover.style.transform = '';
+            }
+            document.body.classList.remove('popover-open');
             currentOpenSphere = null;
         }
 
@@ -2609,6 +2794,20 @@
         document.addEventListener('click', function(e) {
             if (!e.target.closest('.sphere-popover') && !e.target.closest('.care-circle')) {
                 closePopover();
+            }
+        });
+
+        window.addEventListener('resize', () => {
+            if (nav && window.innerWidth > 1024) {
+                nav.classList.add('hidden');
+                if (navToggleBtn) {
+                    navToggleBtn.setAttribute('aria-expanded', 'false');
+                }
+            }
+
+            if (currentOpenSphere) {
+                const activeCircle = document.querySelector(`.care-circle[data-sphere="${currentOpenSphere}"]`);
+                positionPopover(activeCircle);
             }
         });
 


### PR DESCRIPTION
## Summary
- tune navigation panel styling and responsive rules so the floating menu and controls adapt cleanly on small viewports
- rebuild the concentric circle canvas and popover presentation to scale fluidly and show a mobile-friendly overlay that locks background scrolling
- refresh navigation and popover scripts to manage aria state, close interactions on outside clicks/resizes, and dynamically position tooltips on different screen sizes

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68ca54c038c883328508dcff7fdc081b