### PR TITLE
Constrain hero introductory section width

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,9 @@
 
         .hero-bottom {
             padding: 0 4rem 4rem;
+            max-width: 1100px;
+            width: 100%;
+            margin: 0 auto;
         }
 
         .hero h1 {
@@ -310,9 +313,11 @@
             background: white;
             border-radius: 16px;
             padding: 2.5rem;
-            margin-top: 3rem;
+            margin: 3rem auto 0;
             box-shadow: 0 20px 60px rgba(0,0,0,0.08);
             border: 1px solid var(--border-light);
+            max-width: 960px;
+            width: 100%;
         }
 
         .hero-purpose h2 {


### PR DESCRIPTION
## Summary
- limit the hero intro follow-up section width so the content has more comfortable side padding
- center the hero-purpose card with a max-width to keep the copy from stretching too wide on large screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cb938abb84833287e42677e9011683