### PR TITLE
Refine tactical brief layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1513,9 +1513,6 @@
                        data-es="Convertir al 10% de los oponentes en partidarios es más poderoso que movilizar un 30% más de nuestra base. Uno crea un cambio duradero; el otro crea una reacción violenta.">Converting 10% of opponents into supporters is more powerful than mobilizing 30% more of our base. One creates lasting change; the other creates backlash.</p>
                 </div>
                 
-                <p data-en="The strategic reality: Sustainable immigration reform requires either overwhelming political dominance we don't have, or value evolution in communities that currently oppose us. Since we lack the numbers for dominance, evolution becomes our only path to lasting victory."
-                   data-es="La realidad estratégica: La reforma migratoria sostenible requiere o un dominio político abrumador que no tenemos, o una evolución de valores en las comunidades que actualmente se oponen a nosotros. Como carecemos de los números para el dominio, la evolución se convierte en nuestro único camino hacia la victoria duradera.">The strategic reality: Sustainable immigration reform requires either overwhelming political dominance we don't have, or value evolution in communities that currently oppose us. Since we lack the numbers for dominance, evolution becomes our only path to lasting victory.</p>
-                
                 <div class="tactical-brief">
                     <div class="tactical-summary">
                         <h2 data-en="Our Tactical Purpose" data-es="Nuestro Propósito Táctico">Our Tactical Purpose</h2>
@@ -1524,41 +1521,14 @@
 
                         <p data-en="Instead, we're recognizing a critical tactical reality: conservatives already hold values that logically support immigrant rights—they just haven't made the connection yet. By revealing these hidden contradictions, we can achieve immediate victories while creating pathways for broader moral development."
                            data-es="En cambio, estamos reconociendo una realidad táctica crítica: los conservadores ya tienen valores que lógicamente apoyan los derechos de los inmigrantes—simplemente no han hecho la conexión todavía. Al revelar estas contradicciones ocultas, podemos lograr victorias inmediatas mientras creamos caminos para un desarrollo moral más amplio.">Instead, we're recognizing a critical tactical reality: <strong>conservatives already hold values that logically support immigrant rights—they just haven't made the connection yet.</strong> By revealing these hidden contradictions, we can achieve immediate victories while creating pathways for broader moral development.</p>
+
+                        <p data-en="The strategic reality: Sustainable immigration reform requires either overwhelming political dominance we don't have, or value evolution in communities that currently oppose us. Since we lack the numbers for dominance, evolution becomes our only path to lasting victory."
+                           data-es="La realidad estratégica: La reforma migratoria sostenible requiere o un dominio político abrumador que no tenemos, o una evolución de valores en las comunidades que actualmente se oponen a nosotros. Como carecemos de los números para el dominio, la evolución se convierte en nuestro único camino hacia la victoria duradera.">The strategic reality: Sustainable immigration reform requires either overwhelming political dominance we don't have, or value evolution in communities that currently oppose us. Since we lack the numbers for dominance, evolution becomes our only path to lasting victory.</p>
+
+                        <h3 data-en="Respect for Conservative Strengths" data-es="Respeto por las Fortalezas Conservadoras">Respect for Conservative Strengths</h3>
+                        <p data-en="Stability, family stewardship, local loyalty, and rule-of-law are not obstacles but civic goods. Each position on the Value Compass guards a virtue we all rely on. This framework seeks integration of those goods with fairness and opportunity—never belittlement."
+                           data-es="La estabilidad, la administración familiar, la lealtad local y el estado de derecho no son obstáculos sino bienes cívicos. Cada posición en la Brújula de Valores resguarda una virtud de la que todos dependemos. Este marco busca integrar esos bienes con equidad y oportunidad—nunca menosprecio.">Stability, family stewardship, local loyalty, and rule-of-law are not obstacles but civic goods. Each position on the Value Compass guards a virtue we all rely on. This framework seeks integration of those goods with fairness and opportunity—never belittlement.</p>
                     </div>
-
-                    
-                    <p data-en="The strategic reality: Sustainable immigration reform requires either overwhelming political dominance we don't have, or value evolution in communities that currently oppose us. Since we lack the numbers for dominance, evolution becomes our only path to lasting victory."
-                       data-es="La realidad estratégica: La reforma migratoria sostenible requiere o un dominio político abrumador que no tenemos, o una evolución de valores en las comunidades que actualmente se oponen a nosotros. Como carecemos de los números para el dominio, la evolución se convierte en nuestro único camino hacia la victoria duradera.">The strategic reality: Sustainable immigration reform requires either overwhelming political dominance we don't have, or value evolution in communities that currently oppose us. Since we lack the numbers for dominance, evolution becomes our only path to lasting victory.</p>
-
-                    <h3 data-en="Respect for Conservative Strengths" data-es="Respeto por las Fortalezas Conservadoras">Respect for Conservative Strengths</h3>
-                    <p data-en="Stability, family stewardship, local loyalty, and rule-of-law are not obstacles but civic goods. Each position on the Value Compass guards a virtue we all rely on. This framework seeks integration of those goods with fairness and opportunity—never belittlement."
-                       data-es="La estabilidad, la administración familiar, la lealtad local y el estado de derecho no son obstáculos sino bienes cívicos. Cada posición en la Brújula de Valores resguarda una virtud de la que todos dependemos. Este marco busca integrar esos bienes con equidad y oportunidad—nunca menosprecio.">Stability, family stewardship, local loyalty, and rule-of-law are not obstacles but civic goods. Each position on the Value Compass guards a virtue we all rely on. This framework seeks integration of those goods with fairness and opportunity—never belittlement.</p>
-
-                    <div class="tactical-brief">
-                        <div class="tactical-summary">
-                            <h2 data-en="Our Tactical Purpose" data-es="Nuestro Propósito Táctico">Our Tactical Purpose</h2>
-                            <p data-en="This framework provides a strategic approach to immigration advocacy that achieves immediate policy wins while laying groundwork for long-term value evolution. We're not trying to reinforce conservative frameworks or pretend all moral positions are equal."
-                               data-es="Este marco proporciona un enfoque estratégico para la defensa de la inmigración que logra victorias políticas inmediatas mientras sienta las bases para la evolución de valores a largo plazo. No estamos tratando de reforzar marcos conservadores o pretender que todas las posiciones morales son iguales.">This framework provides a strategic approach to immigration advocacy that achieves immediate policy wins while laying groundwork for long-term value evolution. We're not trying to reinforce conservative frameworks or pretend all moral positions are equal.</p>
-
-                            <p data-en="Instead, we're recognizing a critical tactical reality: conservatives already hold values that logically support immigrant rights—they just haven't made the connection yet. By revealing these hidden contradictions, we can achieve immediate victories while creating pathways for broader moral development."
-                               data-es="En cambio, estamos reconociendo una realidad táctica crítica: los conservadores ya tienen valores que lógicamente apoyan los derechos de los inmigrantes—simplemente no han hecho la conexión todavía. Al revelar estas contradicciones ocultas, podemos lograr victorias inmediatas mientras creamos caminos para un desarrollo moral más amplio.">Instead, we're recognizing a critical tactical reality: <strong>conservatives already hold values that logically support immigrant rights—they just haven't made the connection yet.</strong> By revealing these hidden contradictions, we can achieve immediate victories while creating pathways for broader moral development.</p>
-                        </div>
-                        <div class="tactical-pillars">
-                            <span class="pillars-kicker" data-en="Strategic Focus" data-es="Enfoque Estratégico">Strategic Focus</span>
-                            <div class="tactical-goals">
-                                <div class="goal-card">
-                                    <h3 data-en="Immediate Win" data-es="Victoria Inmediata">Immediate Win</h3>
-                                    <p data-en="Use existing conservative values to support pro-immigrant policies" data-es="Usar valores conservadores existentes para apoyar políticas pro-inmigrantes">Use existing conservative values to support pro-immigrant policies</p>
-                                </div>
-                                <div class="goal-card">
-                                    <h3 data-en="Avoid Reinforcement" data-es="Evitar Reforzamiento">Avoid Reinforcement</h3>
-                                    <p data-en="Never strengthen narrow moral frameworks or exclusionary thinking" data-es="Nunca fortalecer marcos morales estrechos o pensamientos excluyentes">Never strengthen narrow moral frameworks or exclusionary thinking</p>
-                                </div>
-                                <div class="goal-card">
-                                    <h3 data-en="Create Evolution" data-es="Crear Evolución">Create Evolution</h3>
-                                    <p data-en="Build bridges that naturally lead to expanded circles of moral concern" data-es="Construir puentes que naturalmente lleven a círculos expandidos de preocupación moral">Build bridges that naturally lead to expanded circles of moral concern</p>
-                                </div>
-
                     <div class="tactical-pillars">
                         <span class="pillars-kicker" data-en="Strategic Focus" data-es="Enfoque Estratégico">Strategic Focus</span>
                         <div class="tactical-goals">
@@ -1573,7 +1543,6 @@
                             <div class="goal-card">
                                 <h3 data-en="Create Evolution" data-es="Crear Evolución">Create Evolution</h3>
                                 <p data-en="Build bridges that naturally lead to expanded circles of moral concern" data-es="Construir puentes que naturalmente lleven a círculos expandidos de preocupación moral">Build bridges that naturally lead to expanded circles of moral concern</p>
-
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- simplify the tactical brief markup so the summary and strategic focus cards render side by side without duplicated blocks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cb99ff9cfc8332ac07f83d62065cbe