### PR TITLE
Adjust mobile spacing after citation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1411,6 +1411,17 @@
                 font-size: 1rem;
             }
         }
+
+        @media (max-width: 480px) {
+            .section {
+                padding: 2.5rem 0;
+            }
+
+            .citation {
+                margin-top: 0.75rem;
+                padding-top: 0.75rem;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- reduce vertical padding for content sections on very small screens to tighten gaps between sections
- slightly trim citation spacing on mobile to keep related notes connected to surrounding content

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68cc9be322148332ab116ef6b02bd733